### PR TITLE
Update main.c

### DIFF
--- a/r92su/main.c
+++ b/r92su/main.c
@@ -716,7 +716,7 @@ report_cfg80211:
 	case NL80211_IFTYPE_ADHOC:
 		if (status == WLAN_STATUS_SUCCESS) {
 			cfg80211_ibss_joined(r92su->wdev.netdev,
-					     join_bss->bss.bssid, GFP_KERNEL);
+					     join_bss->bss.bssid, r92su->current_channel, GFP_KERNEL);
 		}
 		break;
 


### PR DESCRIPTION
cfg80211_ibss_joined now requires a channel argument as of kernel 3.15, added r92su->current_channel ... fixed the compile error, but I'm completely new to this and pretty much crash-coursed C just to fix this compile error... so if it's wrong please let me know how and why.  Thanks!
